### PR TITLE
Prohibit friend accounts

### DIFF
--- a/textassembler_web/templates/textassembler_web/unauthorized.html
+++ b/textassembler_web/templates/textassembler_web/unauthorized.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Access Information</h2>
+  <p>University faculty, staff, students and others who have UM-issued usernames should use the <a href="/login">UM Login</a>.</p>
+{% endblock %}

--- a/textassembler_web/urls.py
+++ b/textassembler_web/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('', views.login, name='login'),
     path('login', views.login, name='login'),
     path('logout', views.logout, name='logout'),
+    path('unauthorized', views.unauthorized, name='unauthorized'),
     path('search', views.search, name='search'),
     path('about', views.about, name='about'),
     path('mysearches', views.mysearches, name='mysearches'),

--- a/textassembler_web/views/__init__.py
+++ b/textassembler_web/views/__init__.py
@@ -4,6 +4,7 @@ Import all the views
 from .search import * #pylint: disable=wildcard-import
 from .login import * #pylint: disable=wildcard-import
 from .logout import * #pylint: disable=wildcard-import
+from .unauthorized import * #pylint: disable=wildcard-import
 from .about import * #pylint: disable=wildcard-import
 from .mysearches import * #pylint: disable=wildcard-import
 from .admin_users import * #pylint: disable=wildcard-import

--- a/textassembler_web/views/login.py
+++ b/textassembler_web/views/login.py
@@ -27,7 +27,10 @@ def login(request):
     # Check if the logon was successful already
     if request.META.get('REMOTE_USER', False):
         logging.debug("Found signed-in Cosign user")
-        request.session['userid'] = request.META['REMOTE_USER']
+        remote_user = request.META['REMOTE_USER']
+        if '@' in remote_user:
+            return redirect('/logout')
+        request.session['userid'] = remote_user
         request.session['is_admin'] = get_is_admin(request.session['userid'])
         return redirect('/search')
     else:

--- a/textassembler_web/views/unauthorized.py
+++ b/textassembler_web/views/unauthorized.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+def unauthorized(request):
+
+    return render(request, "textassembler_web/unauthorized.html")


### PR DESCRIPTION
If the valid remote user has an '@' in it, it must be an email address, and therefore a friend account. Friend accounts should be redirected to a page that doesn't allow them to access the service.